### PR TITLE
Update the import paths for Caddy

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 
 	"github.com/simia-tech/caddy-locale/method"
 )

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/setup.go
+++ b/setup.go
@@ -3,8 +3,8 @@ package locale
 import (
 	"strings"
 
-	"github.com/mholt/caddy"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/caddyserver/caddy"
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 
 	"github.com/simia-tech/caddy-locale/method"
 )

--- a/setup_test.go
+++ b/setup_test.go
@@ -3,7 +3,7 @@ package locale
 import (
 	"testing"
 
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 


### PR DESCRIPTION
This pull request fixes #7  by making caddy-locale compatible with Caddy v1.0.1+ 